### PR TITLE
Fcom 207 content options

### DIFF
--- a/Frends.Community.Azure.Blob.Tests/DeleteTest.cs
+++ b/Frends.Community.Azure.Blob.Tests/DeleteTest.cs
@@ -1,9 +1,8 @@
-﻿using TestConfigurationHandler;
-using Microsoft.WindowsAzure.Storage.Blob;
-using System;
+﻿using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using TestConfigurationHandler;
 
 namespace Frends.Community.Azure.Blob.Tests
 {
@@ -11,25 +10,20 @@ namespace Frends.Community.Azure.Blob.Tests
     public class DeleteTest
     {
         /// <summary>
-        /// Container name for tests
-        /// </summary>
-        private readonly string _containerName = "test-container";
-
-        /// <summary>
-        /// Connection string for Azure Storage Emulator
+        ///     Connection string for Azure Storage Emulator
         /// </summary>
         private readonly string _connectionString = ConfigHandler.ReadConfigValue("HiQ.AzureBlobStorage.ConnString");
 
         /// <summary>
-        /// Some random file for test purposes
+        ///     Container name for tests
         /// </summary>
-        private string _testFilePath = $@"{AppDomain.CurrentDomain.BaseDirectory}\TestFiles\TestFile.xml";
+        private readonly string _containerName = "test-container";
 
         [TestCleanup]
         public async Task Cleanup()
         {
             // delete whole container after running tests
-            CloudBlobContainer container = Utils.GetBlobContainer(_connectionString, _containerName);
+            var container = Utils.GetBlobContainer(_connectionString, _containerName);
             await container.DeleteIfExistsAsync();
         }
 
@@ -68,18 +62,20 @@ namespace Frends.Community.Azure.Blob.Tests
 
             var result = await DeleteTask.DeleteBlobAsync(input, options, new CancellationToken());
 
-            Assert.IsTrue(result.Success, "DeleteBlob should've returned true when trying to delete blob in non existing container");
+            Assert.IsTrue(result.Success,
+                "DeleteBlob should've returned true when trying to delete blob in non existing container");
         }
 
         [TestMethod]
         public async Task DeleteContainerAsync_ShouldReturnTrueWithNonexistingContainer()
         {
-            var inputProperties = new DeleteContainerProperties { ContainerName = Guid.NewGuid().ToString() };
-            var connection = new ContainerConnectionProperties { ConnectionString = _connectionString };
+            var inputProperties = new DeleteContainerProperties {ContainerName = Guid.NewGuid().ToString()};
+            var connection = new ContainerConnectionProperties {ConnectionString = _connectionString};
 
             var result = await DeleteTask.DeleteContainerAsync(inputProperties, connection, new CancellationToken());
 
-            Assert.IsTrue(result.Success, "DeleteContainer should've returned true when trying to delete non existing container");
+            Assert.IsTrue(result.Success,
+                "DeleteContainer should've returned true when trying to delete non existing container");
         }
     }
 }

--- a/Frends.Community.Azure.Blob.Tests/ListTests.cs
+++ b/Frends.Community.Azure.Blob.Tests/ListTests.cs
@@ -1,11 +1,8 @@
-﻿using TestConfigurationHandler;
-using Microsoft.WindowsAzure.Storage.Blob;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using System;
+using System.Globalization;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using TestConfigurationHandler;
 
 namespace Frends.Community.Azure.Blob.Tests
 {
@@ -13,40 +10,45 @@ namespace Frends.Community.Azure.Blob.Tests
     public class ListTests
     {
         /// <summary>
-        /// Container name for tests
-        /// </summary>
-        private string _containerName;
-        
-        /// <summary>
-        /// Connection string for Azure Storage Emulator
+        ///     Connection string for Azure Storage Emulator
         /// </summary>
         private readonly string _connectionString = ConfigHandler.ReadConfigValue("HiQ.AzureBlobStorage.ConnString");
 
         /// <summary>
-        /// Test blob name
+        ///     Test blob name
         /// </summary>
         private readonly string _testBlob = "test-blob.txt";
 
         /// <summary>
-        /// Some random file for test purposes
+        ///     Container name for tests
         /// </summary>
-        private string _testFilePath = $@"{AppDomain.CurrentDomain.BaseDirectory}\TestFiles\TestFile.xml";
+        private string _containerName;
 
         private ListSourceProperties _sourceProperties;
+
+        /// <summary>
+        ///     Some random file for test purposes
+        /// </summary>
+        private readonly string _testFilePath = $@"{AppDomain.CurrentDomain.BaseDirectory}\TestFiles\TestFile.xml";
 
         [TestInitialize]
         public async Task TestSetup()
         {
             // Generate unique container name to avoid conflicts when running multiple tests
-            _containerName = $"test-container{DateTime.Now.ToString("mmssffffff")}";
+            _containerName = $"test-container{DateTime.Now.ToString("mmssffffff", CultureInfo.InvariantCulture)}";
 
-            _sourceProperties = new ListSourceProperties { ConnectionString = _connectionString, ContainerName = _containerName, FlatBlobListing = false };
+            _sourceProperties = new ListSourceProperties
+            {
+                ConnectionString = _connectionString,
+                ContainerName = _containerName,
+                FlatBlobListing = false
+            };
 
             var container = Utils.GetBlobContainer(_connectionString, _containerName);
             await container.CreateIfNotExistsAsync();
 
             // Retrieve reference to a blob named "myblob".
-            CloudBlockBlob blockBlob = container.GetBlockBlobReference(_testBlob);
+            var blockBlob = container.GetBlockBlobReference(_testBlob);
             await blockBlob.UploadFromFileAsync(_testFilePath);
             var blobWithDir = container.GetBlockBlobReference("directory/test-blob2.txt");
             await blobWithDir.UploadFromFileAsync(_testFilePath);
@@ -56,7 +58,7 @@ namespace Frends.Community.Azure.Blob.Tests
         public async Task Cleanup()
         {
             // delete whole container after running tests
-            CloudBlobContainer container = Utils.GetBlobContainer(_connectionString, _containerName);
+            var container = Utils.GetBlobContainer(_connectionString, _containerName);
             await container.DeleteIfExistsAsync();
         }
 

--- a/Frends.Community.Azure.Blob.Tests/Properties/AssemblyInfo.cs
+++ b/Frends.Community.Azure.Blob.Tests/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following

--- a/Frends.Community.Azure.Blob.Tests/TestFiles/TestFile.xml
+++ b/Frends.Community.Azure.Blob.Tests/TestFiles/TestFile.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
+
 <root>
   <input>WhatHasBeenSeenCannotBeUnseen</input>
 </root>

--- a/Frends.Community.Azure.Blob.Tests/UploadTest.cs
+++ b/Frends.Community.Azure.Blob.Tests/UploadTest.cs
@@ -4,6 +4,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.WindowsAzure.Storage.Blob;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.IO;
+using System.Linq.Expressions;
 
 namespace Frends.Community.Azure.Blob.Tests
 {
@@ -24,7 +26,7 @@ namespace Frends.Community.Azure.Blob.Tests
         /// Some random file for test purposes
         /// </summary>
         private string _testFilePath = $@"{AppDomain.CurrentDomain.BaseDirectory}\TestFiles\TestFile.xml";
-
+        /*
         [TestInitialize]
         public void TestSetup()
         {
@@ -39,7 +41,6 @@ namespace Frends.Community.Azure.Blob.Tests
             CloudBlobContainer container = Utils.GetBlobContainer(_connectionString, _containerName);
             await container.DeleteIfExistsAsync();
         }
-
         [TestMethod]
         [ExpectedException(typeof(ArgumentException))]
         public async Task UploadFileAsync_ShouldThrowArgumentExceptionIfFileWasNotFound()
@@ -97,5 +98,53 @@ namespace Frends.Community.Azure.Blob.Tests
 
             StringAssert.EndsWith(result.Uri, $"{_containerName}/RenamedFile.xml");
         }
+        */
+        [TestMethod]
+        public async Task UploadFileAsync_NewShit()
+        {
+            var accName = "devstoreaccount1";
+            
+            var accKey =
+                "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==";
+        
+            var containerName = "testcont";
+
+            var connectionString = "UseDevelopmentStorage=true;DevelopmentStorageProxyUri=http://127.0.0.1:10000/";
+            
+            var filepath = @"c:\testfile\TestFile.xml";
+
+            var input = new UploadInput
+            {
+                SourceFile = filepath,
+                Compress = false,
+                ContentsOnly = true
+            };
+
+            var guid = Guid.NewGuid().ToString();
+
+            var options = new DestinationProperties
+            {
+                ContainerName = containerName,
+                BlobType = AzureBlobType.Block,
+                ParallelOperations = 24,
+                ConnectionString = connectionString,
+                Overwrite = false,
+                CreateContainerIfItDoesNotExist = true,
+                ContentType = "text/xml",
+                FileEncoding = "utf8",
+                RenameTo = guid + ".gz"
+            };
+            var container = Utils.GetBlobContainer(connectionString, containerName);
+
+            var result = await UploadTask.UploadFileAsync(input, options, new CancellationToken());
+            var blobResult = Utils.GetCloudBlob(container, "TestFile.xml", AzureBlobType.Block);
+            
+            var info = new FileInfo(filepath);
+            using(var stream = info.Open(FileMode.Open))
+            StringAssert.EndsWith(result.Uri, $"{containerName}/{guid}.gz");
+            Assert.IsTrue(blobResult.Exists(), "Uploaded TestFile.xml blob should exist");
+
+        }
+        
     }
 }

--- a/Frends.Community.Azure.Blob.Tests/UtilsTests.cs
+++ b/Frends.Community.Azure.Blob.Tests/UtilsTests.cs
@@ -8,10 +8,10 @@ namespace Frends.Community.Azure.Blob.Tests
     [TestClass]
     public class UtilsTests
     {
-        private string _testDirectory;
         private string _existingFileName;
-        private string _testPath;
         private FileInfo _file;
+        private string _testDirectory;
+        private string _testPath;
 
         [TestInitialize]
         public void TestSetup()
@@ -23,8 +23,8 @@ namespace Frends.Community.Azure.Blob.Tests
             _testPath = Path.Combine(_testDirectory, _existingFileName);
             File.WriteAllText(_testPath, "I'm walking here! I'm walking here!");
             _file = new FileInfo(_testPath);
-            
-             if (!_file.Exists) throw new Exception("File Be Not Present.");
+
+            if (!_file.Exists) throw new Exception("File Be Not Present.");
         }
 
         [TestCleanup]
@@ -69,7 +69,7 @@ namespace Frends.Community.Azure.Blob.Tests
         }
 
         [TestMethod]
-        public void GetStream_ReturnsReadableAndWriteableStream()
+        public void GetStream_ReturnsReadableStream()
         {
             // UploadAsync needs readable stream.
             using (var stream = Utils.GetStream(false, false, Encoding.UTF8, _file))
@@ -81,49 +81,57 @@ namespace Frends.Community.Azure.Blob.Tests
             {
                 Assert.IsTrue(stream.CanRead);
             }
-            
+
             using (var stream = Utils.GetStream(true, false, Encoding.UTF8, _file))
             {
                 Assert.IsTrue(stream.CanRead);
             }
-            
+
             using (var stream = Utils.GetStream(true, true, Encoding.UTF8, _file))
             {
                 Assert.IsTrue(stream.CanRead);
             }
-            
-            using(var file = _file.Open(FileMode.Open, FileAccess.Read))
+
+            using (var file = _file.Open(FileMode.Open, FileAccess.Read))
+            {
                 Assert.IsTrue(file.CanRead); // == streams dispose and file is closed properly.
+            }
         }
 
         [TestMethod]
         public void GetStream_ReturnsFileUncompressed()
         {
-            using(var stream = Utils.GetStream(false, true, Encoding.UTF8, _file))
+            using (var stream = Utils.GetStream(false, true, Encoding.UTF8, _file))
+            {
                 Assert.AreEqual(
                     stream.Length,
                     Encoding.UTF8.GetBytes(File.ReadAllText(_file.FullName)).Length
-                    );
+                );
+            }
         }
 
         [TestMethod]
         public void GetStream_ReturnsFileCompressed()
         {
-            using(var stream = Utils.GetStream(true, false, Encoding.UTF8, _file))
+            using (var stream = Utils.GetStream(true, false, Encoding.UTF8, _file))
+            {
                 Assert.AreNotEqual(
                     stream.Length,
                     Encoding.UTF8.GetBytes(File.ReadAllText(_file.FullName)).Length
                 );
+            }
         }
 
         [TestMethod]
         public void GetStream_ReturnsCompressedMemoryStream()
         {
             using (var stream = Utils.GetStream(true, false, Encoding.UTF8, _file))
+            {
                 Assert.IsTrue(
                     stream.Length != Encoding.UTF8.GetBytes(File.ReadAllText(_file.FullName)).Length &&
                     stream is MemoryStream
-                    );
+                );
+            }
         }
     }
 }

--- a/Frends.Community.Azure.Blob.Tests/UtilsTests.cs
+++ b/Frends.Community.Azure.Blob.Tests/UtilsTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Text;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Frends.Community.Azure.Blob.Tests
@@ -9,6 +10,8 @@ namespace Frends.Community.Azure.Blob.Tests
     {
         private string _testDirectory;
         private string _existingFileName;
+        private string _testPath;
+        private FileInfo _file;
 
         [TestInitialize]
         public void TestSetup()
@@ -17,8 +20,11 @@ namespace Frends.Community.Azure.Blob.Tests
             // create test folder 
             _testDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
             Directory.CreateDirectory(_testDirectory);
-
-            File.WriteAllText(Path.Combine(_testDirectory, _existingFileName), "I'm walking here! I'm walking here!");
+            _testPath = Path.Combine(_testDirectory, _existingFileName);
+            File.WriteAllText(_testPath, "I'm walking here! I'm walking here!");
+            _file = new FileInfo(_testPath);
+            
+             if (!_file.Exists) throw new Exception("File Be Not Present.");
         }
 
         [TestCleanup]
@@ -60,6 +66,64 @@ namespace Frends.Community.Azure.Blob.Tests
             // we should have 11 files in test directory, last being 'existing_file(10).txt'
             Assert.AreEqual(11, Directory.GetFiles(_testDirectory, "*.txt").Length);
             Assert.IsTrue(File.Exists(Path.Combine(_testDirectory, "existing_file(10).txt")));
+        }
+
+        [TestMethod]
+        public void GetStream_ReturnsReadableAndWriteableStream()
+        {
+            // UploadAsync needs readable stream.
+            using (var stream = Utils.GetStream(false, false, Encoding.UTF8, _file))
+            {
+                Assert.IsTrue(stream.CanRead);
+            }
+
+            using (var stream = Utils.GetStream(false, true, Encoding.UTF8, _file))
+            {
+                Assert.IsTrue(stream.CanRead);
+            }
+            
+            using (var stream = Utils.GetStream(true, false, Encoding.UTF8, _file))
+            {
+                Assert.IsTrue(stream.CanRead);
+            }
+            
+            using (var stream = Utils.GetStream(true, true, Encoding.UTF8, _file))
+            {
+                Assert.IsTrue(stream.CanRead);
+            }
+            
+            using(var file = _file.Open(FileMode.Open, FileAccess.Read))
+                Assert.IsTrue(file.CanRead); // file is closed properly.
+        }
+
+        [TestMethod]
+        public void GetStream_ReturnsFileUncompressed()
+        {
+            using(var stream = Utils.GetStream(false, true, Encoding.UTF8, _file))
+                Assert.AreEqual(
+                    stream.Length,
+                    Encoding.UTF8.GetBytes(File.ReadAllText(_file.FullName)).Length
+                    );
+        }
+
+        [TestMethod]
+        public void GetStream_ReturnsFileCompressed()
+        {
+            using(var stream = Utils.GetStream(true, false, Encoding.UTF8, _file))
+                Assert.AreNotEqual(
+                    stream.Length,
+                    Encoding.UTF8.GetBytes(File.ReadAllText(_file.FullName)).Length
+                );
+        }
+
+        [TestMethod]
+        public void GetStream_ReturnsCompressedMemoryStream()
+        {
+            using (var stream = Utils.GetStream(true, false, Encoding.UTF8, _file))
+                Assert.IsTrue(
+                    stream.Length != Encoding.UTF8.GetBytes(File.ReadAllText(_file.FullName)).Length &&
+                    stream is MemoryStream
+                    );
         }
     }
 }

--- a/Frends.Community.Azure.Blob.Tests/UtilsTests.cs
+++ b/Frends.Community.Azure.Blob.Tests/UtilsTests.cs
@@ -93,7 +93,7 @@ namespace Frends.Community.Azure.Blob.Tests
             }
             
             using(var file = _file.Open(FileMode.Open, FileAccess.Read))
-                Assert.IsTrue(file.CanRead); // file is closed properly.
+                Assert.IsTrue(file.CanRead); // == streams dispose and file is closed properly.
         }
 
         [TestMethod]

--- a/Frends.Community.Azure.Blob.Tests/app.config
+++ b/Frends.Community.Azure.Blob.Tests/app.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
+
 <configuration>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">

--- a/Frends.Community.Azure.Blob.Tests/config.json
+++ b/Frends.Community.Azure.Blob.Tests/config.json
@@ -1,0 +1,5 @@
+{
+    "configlist": [
+        { "key": "HiQ.AzureBlobStorage.ConnString", "value": "UseDevelopmentStorage=true" }
+    ]
+}

--- a/Frends.Community.Azure.Blob.Tests/packages.config
+++ b/Frends.Community.Azure.Blob.Tests/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
+
 <packages>
   <package id="Microsoft.Azure.KeyVault.Core" version="3.0.1" targetFramework="net452" />
   <package id="Microsoft.Azure.Storage.DataMovement" version="0.7.1" targetFramework="net452" />

--- a/Frends.Community.Azure.Blob/ListTask.cs
+++ b/Frends.Community.Azure.Blob/ListTask.cs
@@ -1,8 +1,7 @@
-﻿using System.ComponentModel.DataAnnotations;
-using Microsoft.WindowsAzure.Storage.Blob;
-using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+using Microsoft.WindowsAzure.Storage.Blob;
 
 #pragma warning disable CS1591
 
@@ -11,7 +10,7 @@ namespace Frends.Community.Azure.Blob
     public class ListTask
     {
         /// <summary>
-        /// List blobs in container. See See https://github.com/CommunityHiQ/Frends.Community.Azure.Blob
+        ///     List blobs in container. See See https://github.com/CommunityHiQ/Frends.Community.Azure.Blob
         /// </summary>
         /// <param name="source"></param>
         /// <returns>Object { List&lt;Object&gt; { string Name, string Uri, string BlobType }}</returns>
@@ -21,53 +20,72 @@ namespace Frends.Community.Azure.Blob
 
             var blobs = new List<BlobData>();
 
-            foreach(IListBlobItem item in container.ListBlobs(String.IsNullOrWhiteSpace(source.Prefix) ? null : source.Prefix, source.FlatBlobListing))
+            foreach (var item in container.ListBlobs(string.IsNullOrWhiteSpace(source.Prefix) ? null : source.Prefix,
+                source.FlatBlobListing))
             {
                 var blobType = item.GetType();
-                
-                if(blobType == typeof(CloudBlockBlob))
-                {
-                    var blockBlob = (CloudBlockBlob)item;
-                    blobs.Add(new BlobData { BlobType = "Block", Uri = blockBlob.Uri.ToString(), Name = blockBlob.Name, ETag = blockBlob.Properties.ETag });
 
-                }else if (blobType == typeof(CloudPageBlob))
+                if (blobType == typeof(CloudBlockBlob))
                 {
-                    var pageBlob = (CloudPageBlob)item;
-                    blobs.Add(new BlobData { BlobType = "Page", Uri = pageBlob.Uri.ToString(), Name = pageBlob.Name, ETag = pageBlob.Properties.ETag});
-
-                }else if(blobType == typeof(CloudBlobDirectory))
+                    var blockBlob = (CloudBlockBlob) item;
+                    blobs.Add(new BlobData
+                    {
+                        BlobType = "Block",
+                        Uri = blockBlob.Uri.ToString(),
+                        Name = blockBlob.Name,
+                        ETag = blockBlob.Properties.ETag
+                    });
+                }
+                else if (blobType == typeof(CloudPageBlob))
                 {
-                    var directory = (CloudBlobDirectory)item;
-                    blobs.Add(new BlobData { BlobType = "Directory", Uri = directory.Uri.ToString(), Name = directory.Prefix });
+                    var pageBlob = (CloudPageBlob) item;
+                    blobs.Add(new BlobData
+                    {
+                        BlobType = "Page",
+                        Uri = pageBlob.Uri.ToString(),
+                        Name = pageBlob.Name,
+                        ETag = pageBlob.Properties.ETag
+                    });
+                }
+                else if (blobType == typeof(CloudBlobDirectory))
+                {
+                    var directory = (CloudBlobDirectory) item;
+                    blobs.Add(new BlobData
+                    {
+                        BlobType = "Directory",
+                        Uri = directory.Uri.ToString(),
+                        Name = directory.Prefix
+                    });
                 }
             }
 
-            return new ListBlobsOutput { Blobs = blobs };
+            return new ListBlobsOutput {Blobs = blobs};
         }
     }
+
     public class ListSourceProperties
     {
         /// <summary>
-        /// Connection string to Azure storage
+        ///     Connection string to Azure storage
         /// </summary>
         [DefaultValue("UseDevelopmentStorage=true")]
         [DisplayFormat(DataFormatString = "Text")]
         public string ConnectionString { get; set; }
 
         /// <summary>
-        /// Name of the azure blob storage container where the file is downloaded from.
+        ///     Name of the azure blob storage container where the file is downloaded from.
         /// </summary>
         [DisplayFormat(DataFormatString = "Text")]
         public string ContainerName { get; set; }
 
         /// <summary>
-        /// Specifies whether to list blobs in a flat listing, or whether to list blobs hierarchically, by virtual directory.
+        ///     Specifies whether to list blobs in a flat listing, or whether to list blobs hierarchically, by virtual directory.
         /// </summary>
         [DefaultValue("true")]
         public bool FlatBlobListing { get; set; }
 
         /// <summary>
-        /// Blob prefix used while searching container
+        ///     Blob prefix used while searching container
         /// </summary>
         [DisplayFormat(DataFormatString = "Text")]
         public string Prefix { get; set; }
@@ -77,6 +95,7 @@ namespace Frends.Community.Azure.Blob
     {
         public List<BlobData> Blobs { get; set; }
     }
+
     public class BlobData
     {
         public string BlobType { get; set; }

--- a/Frends.Community.Azure.Blob/Properties/AssemblyInfo.cs
+++ b/Frends.Community.Azure.Blob/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following

--- a/Frends.Community.Azure.Blob/Properties/AssemblyInfo.cs
+++ b/Frends.Community.Azure.Blob/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.3.0")]
-[assembly: AssemblyFileVersion("1.0.3.0")]
+[assembly: AssemblyVersion("1.4.5.0")]
+[assembly: AssemblyFileVersion("1.4.5.0")]

--- a/Frends.Community.Azure.Blob/UploadTask.cs
+++ b/Frends.Community.Azure.Blob/UploadTask.cs
@@ -2,16 +2,11 @@
 using Microsoft.WindowsAzure.Storage.Blob;
 using Microsoft.WindowsAzure.Storage.DataMovement;
 using System;
-using System.CodeDom;
 using System.ComponentModel;
 using System.IO;
-using System.IO.Compression;
-using System.Net.Mime;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Web;
-using Microsoft.WindowsAzure.Storage;
 
 #pragma warning disable CS1591 
 

--- a/Frends.Community.Azure.Blob/UploadTask.cs
+++ b/Frends.Community.Azure.Blob/UploadTask.cs
@@ -89,6 +89,7 @@ namespace Frends.Community.Azure.Blob
                 SetAttributesCallback = (destination) =>
                 {
                     CloudBlob cloudBlob = destination as CloudBlob;
+                    if (cloudBlob == null) throw new ArgumentNullException();
                     cloudBlob.Properties.ContentType = contentType;
                     cloudBlob.Properties.ContentEncoding = input.Compress ? "gzip" : encoding.WebName;
                 },
@@ -99,19 +100,10 @@ namespace Frends.Community.Azure.Blob
             // begin and await for upload to complete
             try
             {
-                /* This works as well.
-                var blob = destinationBlob;
-                blob.Properties.ContentType = contentType;
-                var text = File.ReadAllText(fi.FullName);
-                var content = input.Compress ? Utils.Compress(text) : text;
-                blob.UploadText(
-                    content,
-                    Encoding.UTF8);
-                */
-
                 using (var stream = Utils.GetStream(input.Compress, input.ContentsOnly, encoding, fi))
                 {
-                    await TransferManager.UploadAsync(stream,
+                    await TransferManager.UploadAsync(
+                        stream,
                         destinationBlob, uploadOptions, transferContext,
                         cancellationToken);
                 }

--- a/Frends.Community.Azure.Blob/UploadTask.cs
+++ b/Frends.Community.Azure.Blob/UploadTask.cs
@@ -1,12 +1,12 @@
-﻿using System.ComponentModel.DataAnnotations;
-using Microsoft.WindowsAzure.Storage.Blob;
-using Microsoft.WindowsAzure.Storage.DataMovement;
-using System;
+﻿using System;
 using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Web;
+using Microsoft.WindowsAzure.Storage.Blob;
+using Microsoft.WindowsAzure.Storage.DataMovement;
 
 #pragma warning disable CS1591 
 
@@ -15,24 +15,24 @@ namespace Frends.Community.Azure.Blob
     public class UploadTask
     {
         /// <summary>
-        /// Uploads a single file to Azure blob storage. See https://github.com/CommunityHiQ/Frends.Community.Azure.Blob
-        /// Will create given container on connection if necessary.
+        ///     Uploads a single file to Azure blob storage. See https://github.com/CommunityHiQ/Frends.Community.Azure.Blob
+        ///     Will create given container on connection if necessary.
         /// </summary>
         /// <returns>Object { string Uri, string SourceFile }</returns>
-        public static async Task<UploadOutput> UploadFileAsync(UploadInput input, DestinationProperties destinationProperties, CancellationToken cancellationToken)
+        public static async Task<UploadOutput> UploadFileAsync(UploadInput input,
+            DestinationProperties destinationProperties, CancellationToken cancellationToken)
         {
             // check for interruptions
             cancellationToken.ThrowIfCancellationRequested();
 
             // check that source file exists
-            FileInfo fi = new FileInfo(input.SourceFile);
+            var fi = new FileInfo(input.SourceFile);
             if (!fi.Exists)
-            {
                 throw new ArgumentException($"Source file {input.SourceFile} does not exist", nameof(input.SourceFile));
-            }
 
             // get container
-            CloudBlobContainer container = Utils.GetBlobContainer(destinationProperties.ConnectionString, destinationProperties.ContainerName);
+            var container = Utils.GetBlobContainer(destinationProperties.ConnectionString,
+                destinationProperties.ContainerName);
 
             // check for interruptions
             cancellationToken.ThrowIfCancellationRequested();
@@ -40,10 +40,7 @@ namespace Frends.Community.Azure.Blob
             try
             {
                 if (destinationProperties.CreateContainerIfItDoesNotExist)
-                {
-                    // create the container if necessary
                     await container.CreateIfNotExistsAsync(cancellationToken);
-                }
             }
             catch (Exception ex)
             {
@@ -51,27 +48,24 @@ namespace Frends.Community.Azure.Blob
             }
 
             // get the destination blob, rename if necessary
-            CloudBlob destinationBlob = Utils.GetCloudBlob(container, 
-                string.IsNullOrWhiteSpace(destinationProperties.RenameTo) ? fi.Name : destinationProperties.RenameTo, 
+            var destinationBlob = Utils.GetCloudBlob(container,
+                string.IsNullOrWhiteSpace(destinationProperties.RenameTo) ? fi.Name : destinationProperties.RenameTo,
                 destinationProperties.BlobType);
 
-            var contentType = string.IsNullOrWhiteSpace(destinationProperties.ContentType) ? 
-                    MimeMapping.GetMimeMapping(fi.Name) :
-                    destinationProperties.ContentType;
-            
+            var contentType = string.IsNullOrWhiteSpace(destinationProperties.ContentType)
+                ? MimeMapping.GetMimeMapping(fi.Name)
+                : destinationProperties.ContentType;
+
             var encoding = destinationProperties.FileEncoding.ConvertToEncoding();
 
             // delete blob if user requested overwrite
-            if (destinationProperties.Overwrite)
-            {
-                await destinationBlob.DeleteIfExistsAsync(cancellationToken);
-            }
+            if (destinationProperties.Overwrite) await destinationBlob.DeleteIfExistsAsync(cancellationToken);
 
             // setup the number of the concurrent operations
             TransferManager.Configurations.ParallelOperations = destinationProperties.ParallelOperations;
 
             // Use UploadOptions to set ContentType of destination CloudBlob
-            UploadOptions uploadOptions = new UploadOptions();
+            var uploadOptions = new UploadOptions();
 
             var progressHandler = new Progress<TransferStatus>(progress =>
             {
@@ -79,19 +73,19 @@ namespace Frends.Community.Azure.Blob
             });
 
             // Setup the transfer context and track the upload progress
-            SingleTransferContext transferContext = new SingleTransferContext
+            var transferContext = new SingleTransferContext
             {
-                SetAttributesCallback = (destination) =>
+                SetAttributesCallback = destination =>
                 {
-                    CloudBlob cloudBlob = destination as CloudBlob;
-                    if (cloudBlob == null) throw new ArgumentNullException();
+                    if (!(destination is CloudBlob)) throw new Exception("We did not get CloudBlob reference. ");
+                    var cloudBlob = (CloudBlob) destination;
                     cloudBlob.Properties.ContentType = contentType;
                     cloudBlob.Properties.ContentEncoding = input.Compress ? "gzip" : encoding.WebName;
                 },
 
                 ProgressHandler = progressHandler
             };
-            
+
             // begin and await for upload to complete
             try
             {
@@ -107,9 +101,9 @@ namespace Frends.Community.Azure.Blob
             {
                 throw new Exception("UploadFileAsync: Error occured while uploading file to blob storage", e);
             }
-            
+
             // return uri to uploaded blob and source file path
-            return new UploadOutput { SourceFile = input.SourceFile, Uri = destinationBlob.Uri.ToString() };
+            return new UploadOutput {SourceFile = input.SourceFile, Uri = destinationBlob.Uri.ToString()};
         }
     }
 
@@ -122,7 +116,7 @@ namespace Frends.Community.Azure.Blob
     public class DestinationProperties
     {
         /// <summary>
-        /// Connection string to Azure storage
+        ///     Connection string to Azure storage
         /// </summary>
         [DefaultValue("UseDevelopmentStorage=true")]
         [DisplayName("Connection String")]
@@ -130,9 +124,9 @@ namespace Frends.Community.Azure.Blob
         public string ConnectionString { get; set; }
 
         /// <summary>
-        /// Name of the azure blob storage container where the data will be uploaded.
-        /// Naming: lowercase
-        /// Valid chars: alphanumeric and dash, but cannot start or end with dash
+        ///     Name of the azure blob storage container where the data will be uploaded.
+        ///     Naming: lowercase
+        ///     Valid chars: alphanumeric and dash, but cannot start or end with dash
         /// </summary>
         [DefaultValue("test-container")]
         [DisplayName("Container Name")]
@@ -140,20 +134,20 @@ namespace Frends.Community.Azure.Blob
         public string ContainerName { get; set; }
 
         /// <summary>
-        /// Determines if the container should be created if it does not exist
+        ///     Determines if the container should be created if it does not exist
         /// </summary>
         [DisplayName("Create container if it does not exist")]
         public bool CreateContainerIfItDoesNotExist { get; set; }
 
         /// <summary>
-        /// Azure blob type to upload: Append, Block or Page
+        ///     Azure blob type to upload: Append, Block or Page
         /// </summary>
         [DefaultValue(AzureBlobType.Block)]
         [DisplayName("Blob Type")]
         public AzureBlobType BlobType { get; set; }
 
         /// <summary>
-        /// Source file can be renamed to this name in azure blob storage
+        ///     Source file can be renamed to this name in azure blob storage
         /// </summary>
         [DefaultValue("")]
         [DisplayName("Rename source file")]
@@ -161,7 +155,7 @@ namespace Frends.Community.Azure.Blob
         public string RenameTo { get; set; }
 
         /// <summary>
-        /// Set desired content-type. If empty, task tries to guess from mime-type.
+        ///     Set desired content-type. If empty, task tries to guess from mime-type.
         /// </summary>
         [DefaultValue("")]
         [DisplayName("Force Content-Type")]
@@ -169,7 +163,7 @@ namespace Frends.Community.Azure.Blob
         public string ContentType { get; set; }
 
         /// <summary>
-        /// Set desired content-encoding. Defaults to UTF8 BOM.
+        ///     Set desired content-encoding. Defaults to UTF8 BOM.
         /// </summary>
         [DefaultValue("")]
         [DisplayName("Force Content-Encoding")]
@@ -177,14 +171,14 @@ namespace Frends.Community.Azure.Blob
         public string FileEncoding { get; set; }
 
         /// <summary>
-        /// Should upload operation overwrite existing file with same name?
+        ///     Should upload operation overwrite existing file with same name?
         /// </summary>
         [DefaultValue(true)]
         [DisplayName("Overwrite existing file")]
         public bool Overwrite { get; set; }
 
         /// <summary>
-        /// How many work items to process concurrently.
+        ///     How many work items to process concurrently.
         /// </summary>
         [DefaultValue(64)]
         [DisplayName("Parallel Operation")]
@@ -199,14 +193,14 @@ namespace Frends.Community.Azure.Blob
         public string SourceFile { get; set; }
 
         /// <summary>
-        /// Uses stream to read file content.
+        ///     Uses stream to read file content.
         /// </summary>
         [DefaultValue(false)]
         [DisplayName("Stream content only")]
         public bool ContentsOnly { get; set; }
 
         /// <summary>
-        /// Works only when transferring stream content.
+        ///     Works only when transferring stream content.
         /// </summary>
         [DefaultValue(false)]
         [DisplayName("Gzip compression")]

--- a/Frends.Community.Azure.Blob/Utils.cs
+++ b/Frends.Community.Azure.Blob/Utils.cs
@@ -1,6 +1,11 @@
-﻿using Microsoft.WindowsAzure.Storage.Blob;
+﻿using System;
+using Microsoft.WindowsAzure.Storage.Blob;
 using Microsoft.WindowsAzure.Storage;
 using System.IO;
+using System.IO.Compression;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
 
 #pragma warning disable CS1591
 
@@ -15,7 +20,7 @@ namespace Frends.Community.Azure.Blob
 
             // initialize blob client
             CloudBlobClient client = account.CreateCloudBlobClient();
-            
+
             return client.GetContainerReference(containerName);
         }
 
@@ -52,11 +57,57 @@ namespace Frends.Community.Azure.Blob
             var name = Path.GetFileNameWithoutExtension(fileName);
             var extension = Path.GetExtension(fileName);
             // loop until available indexed filename found
-            while(File.Exists(Path.Combine(directory, $"{name}({index}){extension}")))
+            while (File.Exists(Path.Combine(directory, $"{name}({index}){extension}")))
             {
                 index++;
             }
+
             return $"{name}({index}){extension}";
+        }
+
+        /// <summary>
+        /// Gets correct stream object. Does not dispose, so use using.
+        /// </summary>
+        /// <param name="compress"></param>
+        /// <param name="file"></param>
+        /// <returns></returns>
+        public static Stream GetStream(bool compress, bool fromString, Encoding encoding, FileInfo file)
+        {
+            byte[] compressed;
+            using (var fileStream = File.OpenRead(file.FullName))
+            {
+                if (!compress && !fromString) return fileStream; // as uncompressed binary
+
+                if (!compress)
+                    return new MemoryStream(
+                        encoding.GetBytes(
+                            new StreamReader(fileStream, encoding)
+                                .ReadToEnd())); // as uncompressed string
+
+                using (var outStream = new MemoryStream())
+                {
+                    using (var gzip = new GZipStream(outStream, CompressionMode.Compress))
+                    {
+                        if (fromString)
+                        {
+                            using (var encodedMemory = new MemoryStream(
+                                encoding.GetBytes(new StreamReader(fileStream, encoding).ReadToEnd())))
+                            {
+                                encodedMemory.CopyTo(gzip); // as compressed string
+                            }
+                        }
+                        else
+                        {
+                            fileStream.CopyTo(gzip); // as compressed binary
+                        }
+                    }
+
+                    compressed = outStream.ToArray();
+                }
+            }
+
+            var memStream = new MemoryStream(compressed);
+            return memStream;
         }
     }
 }

--- a/Frends.Community.Azure.Blob/app.config
+++ b/Frends.Community.Azure.Blob/app.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
+
 <configuration>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">

--- a/Frends.Community.Azure.Blob/packages.config
+++ b/Frends.Community.Azure.Blob/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
+
 <packages>
   <package id="Frends.Tasks.Attributes" version="1.2.0" targetFramework="net452" />
   <package id="Microsoft.Azure.KeyVault.Core" version="3.0.1" targetFramework="net452" />

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Uploads file to target container. If the container doesn't exist, it will be cre
 | Property | Type | Description | Example |
 | -------- | -------- | -------- | -------- |
 | Source File | string | Full path to file that is uploaded. | 'c:\temp\uploadMe.xml' |
+| Contents Only | bool | Reads file content as string and treats content as selected Encoding | true |
+| Compress | bool | Applies gzip compression to file or file content | true |
 | Connection String | string | Connection string to Azure storage | 'UseDevelopmentStorage=true' |
 | Container Name | string | Name of the azure blob storage container where the data will be uploaded. If the container doesn't exist, then it will be created. See [Naming and Referencing Containers](https://docs.microsoft.com/en-us/rest/api/storageservices/naming-and-referencing-containers--blobs--and-metadata) for naming conventions. | 'my-container' |
 | Create container if it does not exist | bool | Tries to create the container if it does not exist. | false |
@@ -39,6 +41,8 @@ Uploads file to target container. If the container doesn't exist, it will be cre
 | Rename To | string | If value is set, uploaded file will be renamed to this. | 'newFileName.xml' |
 | Overwrite | bool | Should upload operation overwrite existing file with same name. | true |
 | ParallelOperations | int | The number of the concurrent operations. | 64 |
+| Content-Type | string | Forces any content-type to file. If empty, tries to guess based on extension and MIME-type | text/xml |
+| Content-Encoding | string | File content is treated as this. Does not affect file encoding when Contents Only is true. If compression is enabled, Content-Type is set as 'gzip' | utf8 |
 
 ### Returns
 
@@ -184,3 +188,4 @@ NOTE: Be sure to merge the latest from "upstream" before making a pull request!
 | 1.2.0 | Wrote documentation according to development quide lines. Added DownloadBlobAsync, ReadBlobContentAsync and ListBlobs tasks. |
 | 1.3.0 | New parameters in multiple tasks. New return value in list task. Tasks now use System.ComponentModel.DataAnnotations |
 | 1.4.0 | Updated dependencies due potential security vulnerabilities. |
+| 1.5.0 | File upload now uses stream. Added options to compress or read file as string with Contents Only. Added Content-Type and Content-Encoding fields. |

--- a/nuspec/Frends.Community.Azure.Blob.nuspec
+++ b/nuspec/Frends.Community.Azure.Blob.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>Frends.Community.Azure.Blob</id>
-    <version>1.4.0</version>
+    <version>1.4.5</version>
     <title>Frends.Community.Azure.Blob</title>
     <authors>HiQ Finland</authors>
     <owners>HiQ Finland</owners>
@@ -16,12 +16,12 @@
         <dependency id="Microsoft.Azure.KeyVault.Core" version="2.0.4" />
         <dependency id="Microsoft.Azure.Storage.DataMovement" version="0.7.1" />
         <dependency id="Microsoft.Data.Edm" version="5.8.3" />
-        <dependency id="Microsoft.Data.OData" version="5.8.4" />
+        <dependency id="Microsoft.Data.OData" version="5.8.3" />
         <dependency id="Microsoft.Data.Services.Client" version="5.8.3" />
         <dependency id="Microsoft.WindowsAzure.ConfigurationManager" version="3.2.3" />
         <dependency id="Newtonsoft.Json" version="10.0.2" />
         <dependency id="System.Spatial" version="5.8.3" />
-        <dependency id="WindowsAzure.Storage" version="9.1.1" />
+        <dependency id="WindowsAzure.Storage" version="9.3.3" />
       </group>
     </dependencies>
     <frameworkAssemblies>

--- a/nuspec/Frends.Community.Azure.Blob.nuspec
+++ b/nuspec/Frends.Community.Azure.Blob.nuspec
@@ -1,4 +1,5 @@
 <?xml version="1.0"?>
+
 <package>
   <metadata>
     <id>Frends.Community.Azure.Blob</id>
@@ -27,15 +28,17 @@
     <frameworkAssemblies>
       <frameworkAssembly assemblyName="System" targetFramework="net452" />
       <frameworkAssembly assemblyName="System.ComponentModel" targetFramework="net452" />
-      <frameworkAssembly assemblyName="System.IO" targetFramework="net452"/>
+      <frameworkAssembly assemblyName="System.IO" targetFramework="net452" />
       <frameworkAssembly assemblyName="System.Threading" targetFramework="net452" />
       <frameworkAssembly assemblyName="System.Threading.Tasks" targetFramework="net452" />
       <frameworkAssembly assemblyName="System.Web" targetFramework="net452" />
     </frameworkAssemblies>
   </metadata>
   <files>
-	  <file src="..\Frends.Community.Azure.Blob\bin\Release\Frends.Community.Azure.Blob.dll" target="lib\net452\Frends.Community.Azure.Blob.dll" />
-    <file src="..\Frends.Community.Azure.Blob\bin\Release\Frends.Community.Azure.Blob.xml" target="lib\net452\Frends.Community.Azure.Blob.xml" />
+    <file src="..\Frends.Community.Azure.Blob\bin\Release\Frends.Community.Azure.Blob.dll"
+          target="lib\net452\Frends.Community.Azure.Blob.dll" />
+    <file src="..\Frends.Community.Azure.Blob\bin\Release\Frends.Community.Azure.Blob.xml"
+          target="lib\net452\Frends.Community.Azure.Blob.xml" />
     <file src="..\Frends.Community.Azure.Blob\FrendsTaskMetadata.json" target="FrendsTaskMetadata.json" />
   </files>
 </package>

--- a/nuspec/Frends.Community.Azure.Blob.nuspec
+++ b/nuspec/Frends.Community.Azure.Blob.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>Frends.Community.Azure.Blob</id>
-    <version>1.4.5</version>
+    <version>1.5.0</version>
     <title>Frends.Community.Azure.Blob</title>
     <authors>HiQ Finland</authors>
     <owners>HiQ Finland</owners>

--- a/nuspec/Frends.Community.Azure.Blob.nuspec
+++ b/nuspec/Frends.Community.Azure.Blob.nuspec
@@ -22,7 +22,7 @@
         <dependency id="Microsoft.WindowsAzure.ConfigurationManager" version="3.2.3" />
         <dependency id="Newtonsoft.Json" version="10.0.2" />
         <dependency id="System.Spatial" version="5.8.3" />
-        <dependency id="WindowsAzure.Storage" version="9.3.3" /><
+        <dependency id="WindowsAzure.Storage" version="9.3.3" />
       </group>
     </dependencies>
     <frameworkAssemblies>


### PR DESCRIPTION
Pull Request is linked to #7 

- Switched UploadAsync to use Streams instead.
- Added Content-Type, can force anything.
- Added Content-Encoding. When using Compress option, Encoding is set as 'gzip'. If left empty, tries to guess from extension and MIME-type.
- Added Compress option. Uses GZipStream to compress file or string.
- Added Contents-Only option which reads file contents and applies encoding from Content-Encoding field.
- Updated md file.
- Incremented nuspec to 1.5.
- Unit tests.
- Refactored with ReSharper Code Cleanup & Code Issues solved. Use previous commit for clearer diff ff508fe21253c77181e12c1a90ce114e2912fdf6

