### PR TITLE
Support for uploading raw string data directly to blob

### DIFF
--- a/Frends.Community.Azure.Blob/FrendsTaskMetadata.json
+++ b/Frends.Community.Azure.Blob/FrendsTaskMetadata.json
@@ -4,6 +4,9 @@
       "TaskMethod": "Frends.Community.Azure.Blob.UploadTask.UploadFileAsync"
     },
     {
+      "TaskMethod": "Frends.Community.Azure.Blob.UploadTask.UploadDataAsync"
+    },
+    {
       "TaskMethod": "Frends.Community.Azure.Blob.ListTask.ListBlobs"
     },
     {

--- a/README.md
+++ b/README.md
@@ -51,6 +51,22 @@ Uploads file to target container. If the container doesn't exist, it will be cre
 | SourceFile | string | Full path of file uploaded | |
 | Uri | string | Uri to uploaded blob | |
 
+## UploadDataAsync
+
+### Properties
+
+| Property | Type | Description | Example |
+| -------- | -------- | -------- | -------- |
+| Data content | string | raw data to upload | 'raw data' |
+| Target File | string | File name in blob | 'c:\temp\uploadMe.xml' |
+
+### Returns
+
+| Property | Type | Description | Example |
+| -------- | -------- | -------- | -------- |
+| SourceFile | string | Full path of file uploaded | |
+| Uri | string | Uri to uploaded blob | |
+
 ## ListBlobs
 List blobs in container.
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Uploads file to target container. If the container doesn't exist, it will be cre
 | Property | Type | Description | Example |
 | -------- | -------- | -------- | -------- |
 | Data content | string | raw data to upload | 'raw data' |
-| Target File | string | File name in blob | 'c:\temp\uploadMe.xml' |
+| Target File | string | File name in blob | 'uploaded.xml' |
 
 ### Returns
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Uploads file to target container. If the container doesn't exist, it will be cre
 
 | Property | Type | Description | Example |
 | -------- | -------- | -------- | -------- |
-| Data content | string | raw data to upload | 'raw data' |
+| Data content | string | raw data to upload, note: uses Content-Encoding variable to determine string encoding, defaults to UTF-8 BOM | 'raw data' |
 | Target File | string | File name in blob | 'uploaded.xml' |
 
 ### Returns


### PR DESCRIPTION
I had a use case where SOAP HTTP message needs to be stored at blob, and I would not prefer to save it to disk just to upload it to azure blob.

Simple addition to just take the string and put it in memorystream and push to blob. Uses the encoding for the string given in Content-Encoding variable.

Also added documentation.