### PR TITLE
Fix for issue #32: UploadFileAsync fails with hierarchical storage accounts because they do not support tags

### DIFF
--- a/Frends.Community.Azure.Blob/Frends.Community.Azure.Blob.csproj
+++ b/Frends.Community.Azure.Blob/Frends.Community.Azure.Blob.csproj
@@ -10,7 +10,7 @@
     <IncludeSource>true</IncludeSource>
     <PackageTags>Frends</PackageTags>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>3.2.1</Version>
+    <Version>3.2.2</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Frends.Community.Azure.Blob/UploadTask.cs
+++ b/Frends.Community.Azure.Blob/UploadTask.cs
@@ -336,7 +336,7 @@ namespace Frends.Community.Azure.Blob
         public bool Compress { get; set; }
 
         /// <summary>
-        ///     Tags for the uploaded blob.
+        ///     Tags for the uploaded blob. Should be set to null if the storage account does not support tags.
         /// </summary>
         public Tag[] Tags { get; set; }
     }

--- a/Frends.Community.Azure.Blob/UploadTask.cs
+++ b/Frends.Community.Azure.Blob/UploadTask.cs
@@ -10,6 +10,7 @@ using Azure.Storage;
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
 using System.Collections.Generic;
+using System.Linq;
 
 #pragma warning disable CS1591
 
@@ -55,11 +56,7 @@ namespace Frends.Community.Azure.Blob
             else
                 fileName = destinationProperties.RenameTo;
 
-            Dictionary<string, string> tags = new Dictionary<string, string>();
-            if (input.Tags != null)
-                if (input.Tags.Length > 0)
-                    foreach (var tag in input.Tags)
-                        tags.Add(tag.Name, tag.Value);
+            Dictionary<string, string> tags = input.Tags?.ToDictionary(tag => tag.Name, tag => tag.Value);
 
             // return uri to uploaded blob and source file path
 

--- a/README.md
+++ b/README.md
@@ -33,12 +33,12 @@ Uploads file to a target container. If the container doesn't exist, it will be c
 
 ### Input
 
-| Property      | Type     | Description                                                           | Example                |
-|---------------|----------|-----------------------------------------------------------------------|------------------------|
-| Source File   | `string` | Full path to file that is uploaded.                                   | 'c:\temp\uploadMe.xml' |
-| Contents Only | `bool`   | Reads file content as string and treats content as selected Encoding. | true                   |
-| Compress      | `bool`   | Applies gzip compression to file or file content.                     | true                   |
-| Tags          | Tag[]    | Index tags for blob.                                                  | See [Tag](#tag)        |
+| Property      | Type     | Description                                                                              | Example                |
+|---------------|----------|------------------------------------------------------------------------------------------|------------------------|
+| Source File   | `string` | Full path to file that is uploaded.                                                      | 'c:\temp\uploadMe.xml' |
+| Contents Only | `bool`   | Reads file content as string and treats content as selected Encoding.                    | true                   |
+| Compress      | `bool`   | Applies gzip compression to file or file content.                                        | true                   |
+| Tags          | Tag[]    | Index tags for blob. Should be set to null if the storage account does not support tags. | See [Tag](#tag)        |
 
 ### Destination properties
 
@@ -281,3 +281,4 @@ NOTE: Be sure to merge the latest from "upstream" before making a pull request!
 | 3.1.0   | UploadFileAsync: New feature to add index tags to uploaded blobs.                                                                                 |
 | 3.2.0   | DownloadBlobAsync: Added option to parse illegal characters when Blob is downloaded. Original Blob name added to result object.                   |
 | 3.2.1   | DownloadBlobAsync: Fixed issue with empty encoding parameter.                                                                                     |
+| 3.2.2   | UploadFileAsync: Fixed issue with tags in hierarchical storage accounts.                                                                          |


### PR DESCRIPTION
Fixes issue #32.

This change sets `tags` to null if user provides `null` as the parameter in Frends.

Afterwards, `tags` is passed as null to `AppendBlob` or `UploadBlockBlob` and Azure.Storage.Blobs handles it.

I've tested the change in customer's environment with blob type: block. I'm unable to add test cases for comprehensive testing, since I do not have a proper test environment.

Some lines were only touched by git normalizing newlines.